### PR TITLE
Breaking change: Use attributes instead of magic consts

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -38,3 +38,6 @@ jobs:
 
     - name: Run test suite
       run: composer run-script test
+
+    - name: Run lint
+      run: composer run-script lint

--- a/src/index.php
+++ b/src/index.php
@@ -44,6 +44,8 @@ interface ISimpleActor extends IActor
     function set_object(SimpleObject $object): void;
 
     function get_object(): SimpleObject;
+
+    function a_function(): bool;
 }
 
 class SimpleObject
@@ -123,6 +125,11 @@ class SimpleActor implements ISimpleActor
     function get_object(): SimpleObject
     {
         return $this->state->complex_object;
+    }
+
+    function a_function(): bool
+    {
+        return true;
     }
 }
 
@@ -336,7 +343,8 @@ function test_actor(): void
     $read_reminder = $actor->get_reminder('increment');
     assert_equals(
         $reminder->due_time->format(\Dapr\Formats::FROM_INTERVAL),
-        $read_reminder->due_time->format(\Dapr\Formats::FROM_INTERVAL)
+        $read_reminder->due_time->format(\Dapr\Formats::FROM_INTERVAL),
+        'time formats are delivered ok'
     );
 
     $timer = new Timer(
@@ -362,6 +370,8 @@ function test_actor(): void
     $saved_object = $actor->get_object();
     assert_equals($object->bar, $saved_object->bar, "[object] saved array should match");
     assert_equals($object->foo, $saved_object->foo, "[object] saved string should match");
+
+    assert_equals(true, $actor->a_function(), 'actor can return a simple value');
 }
 
 function test_pubsub(): void

--- a/src/index.php
+++ b/src/index.php
@@ -8,6 +8,7 @@ use Dapr\Actors\Actor;
 use Dapr\Actors\ActorProxy;
 use Dapr\Actors\ActorRuntime;
 use Dapr\Actors\ActorState;
+use Dapr\Actors\DaprType;
 use Dapr\Actors\IActor;
 use Dapr\Actors\Reminder;
 use Dapr\Actors\Timer;
@@ -33,10 +34,9 @@ function testsub(): void
     );
 }
 
+#[DaprType('SimpleActor')]
 interface ISimpleActor extends IActor
 {
-    public const DAPR_TYPE = 'SimpleActor';
-
     function increment($amount = 1);
 
     function get_count(): int;
@@ -62,16 +62,11 @@ class SimpleActorState extends State
     public SimpleObject $complex_object;
 }
 
+#[DaprType('SimpleActor')]
+#[ActorState('statestore', SimpleActorState::class)]
 class SimpleActor implements ISimpleActor
 {
     use Actor;
-    use ActorState;
-
-    public const STATE_TYPE = [
-        'store'       => 'statestore',
-        'type'        => SimpleActorState::class,
-        'consistency' => StrongLastWrite::class,
-    ];
 
     /**
      * SimpleActor constructor.
@@ -143,7 +138,7 @@ class SimpleState extends State
     }
 }
 
-ActorRuntime::register_actor('SimpleActor', SimpleActor::class);
+ActorRuntime::register_actor(SimpleActor::class);
 Subscribe::to_topic('pubsub', 'test', 'testsub');
 Runtime::register_method('do_tests', 'do_tests', 'GET');
 Runtime::register_method(
@@ -443,22 +438,22 @@ function do_tests()
 {
     header('Content-Type: text/html; charset=UTF-8');
     $tests = [
-        'state_test'             => [
+        'state_test'                => [
             'description' => 'Test setting and getting state',
         ],
-        'state_concurrency'      => [
+        'state_concurrency'         => [
             'description' => 'Tests concurrency of state changes',
         ],
-        'transaction_test'       => [
+        'transaction_test'          => [
             'description' => 'Test transactional state',
         ],
-        'multiple_transactions'  => [
+        'multiple_transactions'     => [
             'description' => 'Test multiple concurrent transactions',
         ],
-        'test_actor'             => [
+        'test_actor'                => [
             'description' => 'Testing some basic actors',
         ],
-        'test_pubsub'            => [
+        'test_pubsub'               => [
             'description' => 'Testing publish/subscribe pattern',
         ],
         'test_invoke_serialization' => [

--- a/src/lib/Actors/Actor.php
+++ b/src/lib/Actors/Actor.php
@@ -35,7 +35,7 @@ trait Actor
         // end function
         $id = $this->get_id();
 
-        $result = DaprClient::post(
+        DaprClient::post(
             DaprClient::get_api("/actors/$type/$id/reminders/{$reminder->name}", null),
             $reminder->to_array()
         );
@@ -113,7 +113,7 @@ trait Actor
         // end function
         $id = $this->get_id();
 
-        $result = DaprClient::post(
+        DaprClient::post(
             DaprClient::get_api("/actors/$type/$id/timers/{$timer->name}"),
             $timer->to_array()
         );
@@ -140,7 +140,7 @@ trait Actor
         // end function
         $id = $this->get_id();
 
-        $result = DaprClient::delete(DaprClient::get_api("/actors/$type/$id/timers/$name"));
+        DaprClient::delete(DaprClient::get_api("/actors/$type/$id/timers/$name"));
         return true;
     }
 }

--- a/src/lib/Actors/Actor.php
+++ b/src/lib/Actors/Actor.php
@@ -26,11 +26,12 @@ trait Actor
         Reminder $reminder
     ): bool {
         // inline function: get name
-        if (isset($this->DAPR_TYPE)) {
-            $type = $this->DAPR_TYPE;
+        $class = new \ReflectionClass($this);
+        $attributes = $class->getAttributes(DaprType::class);
+        if (!empty($attributes)) {
+            $type = $attributes[0]->newInstance()->type;
         } else {
-            $type = explode('\\', get_class($this));
-            $type = array_pop($type);
+            $type = $class->getShortName();
         }
         // end function
         $id = $this->get_id();
@@ -55,11 +56,12 @@ trait Actor
         string $name
     ): ?Reminder {
         // inline function: get name
-        if (isset($this->DAPR_TYPE)) {
-            $type = $this->DAPR_TYPE;
+        $class = new \ReflectionClass($this);
+        $attributes = $class->getAttributes(DaprType::class);
+        if (!empty($attributes)) {
+            $type = $attributes[0]->newInstance()->type;
         } else {
-            $type = explode('\\', get_class($this));
-            $type = array_pop($type);
+            $type = $class->getShortName();
         }
         // end function
         $id = $this->get_id();
@@ -79,11 +81,12 @@ trait Actor
     public function delete_reminder(string $name): bool
     {
         // inline function: get name
-        if (isset($this->DAPR_TYPE)) {
-            $type = $this->DAPR_TYPE;
+        $class = new \ReflectionClass($this);
+        $attributes = $class->getAttributes(DaprType::class);
+        if (!empty($attributes)) {
+            $type = $attributes[0]->newInstance()->type;
         } else {
-            $type = explode('\\', get_class($this));
-            $type = array_pop($type);
+            $type = $class->getShortName();
         }
         // end function
         $id = $this->get_id();
@@ -104,11 +107,12 @@ trait Actor
         Timer $timer,
     ): bool {
         // inline function: get name
-        if (isset($this->DAPR_TYPE)) {
-            $type = $this->DAPR_TYPE;
+        $class = new \ReflectionClass($this);
+        $attributes = $class->getAttributes(DaprType::class);
+        if (!empty($attributes)) {
+            $type = $attributes[0]->newInstance()->type;
         } else {
-            $type = explode('\\', get_class($this));
-            $type = array_pop($type);
+            $type = $class->getShortName();
         }
         // end function
         $id = $this->get_id();
@@ -131,11 +135,12 @@ trait Actor
     public function delete_timer(string $name): bool
     {
         // inline function: get name
-        if (isset($this->DAPR_TYPE)) {
-            $type = $this->DAPR_TYPE;
+        $class = new \ReflectionClass($this);
+        $attributes = $class->getAttributes(DaprType::class);
+        if (!empty($attributes)) {
+            $type = $attributes[0]->newInstance()->type;
         } else {
-            $type = explode('\\', get_class($this));
-            $type = array_pop($type);
+            $type = $class->getShortName();
         }
         // end function
         $id = $this->get_id();

--- a/src/lib/Actors/Actor.php
+++ b/src/lib/Actors/Actor.php
@@ -26,12 +26,16 @@ trait Actor
         Reminder $reminder
     ): bool {
         // inline function: get name
-        $class = new \ReflectionClass($this);
-        $attributes = $class->getAttributes(DaprType::class);
-        if (!empty($attributes)) {
-            $type = $attributes[0]->newInstance()->type;
+        if(isset($this->DAPR_TYPE)) {
+            $type = $this->DAPR_TYPE;
         } else {
-            $type = $class->getShortName();
+            $class      = new \ReflectionClass($this);
+            $attributes = $class->getAttributes(DaprType::class);
+            if ( ! empty($attributes)) {
+                $type = $attributes[0]->newInstance()->type;
+            } else {
+                $type = $class->getShortName();
+            }
         }
         // end function
         $id = $this->get_id();
@@ -56,17 +60,22 @@ trait Actor
         string $name
     ): ?Reminder {
         // inline function: get name
-        $class = new \ReflectionClass($this);
-        $attributes = $class->getAttributes(DaprType::class);
-        if (!empty($attributes)) {
-            $type = $attributes[0]->newInstance()->type;
+        if(isset($this->DAPR_TYPE)) {
+            $type = $this->DAPR_TYPE;
         } else {
-            $type = $class->getShortName();
+            $class      = new \ReflectionClass($this);
+            $attributes = $class->getAttributes(DaprType::class);
+            if ( ! empty($attributes)) {
+                $type = $attributes[0]->newInstance()->type;
+            } else {
+                $type = $class->getShortName();
+            }
         }
         // end function
         $id = $this->get_id();
 
         $result = DaprClient::get(DaprClient::get_api("/actors/$type/$id/reminders/$name"));
+
         return Reminder::from_api($name, $result->data);
     }
 
@@ -81,17 +90,22 @@ trait Actor
     public function delete_reminder(string $name): bool
     {
         // inline function: get name
-        $class = new \ReflectionClass($this);
-        $attributes = $class->getAttributes(DaprType::class);
-        if (!empty($attributes)) {
-            $type = $attributes[0]->newInstance()->type;
+        if(isset($this->DAPR_TYPE)) {
+            $type = $this->DAPR_TYPE;
         } else {
-            $type = $class->getShortName();
+            $class      = new \ReflectionClass($this);
+            $attributes = $class->getAttributes(DaprType::class);
+            if ( ! empty($attributes)) {
+                $type = $attributes[0]->newInstance()->type;
+            } else {
+                $type = $class->getShortName();
+            }
         }
         // end function
         $id = $this->get_id();
 
         DaprClient::delete(DaprClient::get_api("/actors/$type/$id/reminders/$name"));
+
         return true;
     }
 
@@ -107,12 +121,16 @@ trait Actor
         Timer $timer,
     ): bool {
         // inline function: get name
-        $class = new \ReflectionClass($this);
-        $attributes = $class->getAttributes(DaprType::class);
-        if (!empty($attributes)) {
-            $type = $attributes[0]->newInstance()->type;
+        if(isset($this->DAPR_TYPE)) {
+            $type = $this->DAPR_TYPE;
         } else {
-            $type = $class->getShortName();
+            $class      = new \ReflectionClass($this);
+            $attributes = $class->getAttributes(DaprType::class);
+            if ( ! empty($attributes)) {
+                $type = $attributes[0]->newInstance()->type;
+            } else {
+                $type = $class->getShortName();
+            }
         }
         // end function
         $id = $this->get_id();
@@ -121,6 +139,7 @@ trait Actor
             DaprClient::get_api("/actors/$type/$id/timers/{$timer->name}"),
             $timer->to_array()
         );
+
         return true;
     }
 
@@ -135,17 +154,22 @@ trait Actor
     public function delete_timer(string $name): bool
     {
         // inline function: get name
-        $class = new \ReflectionClass($this);
-        $attributes = $class->getAttributes(DaprType::class);
-        if (!empty($attributes)) {
-            $type = $attributes[0]->newInstance()->type;
+        if(isset($this->DAPR_TYPE)) {
+            $type = $this->DAPR_TYPE;
         } else {
-            $type = $class->getShortName();
+            $class      = new \ReflectionClass($this);
+            $attributes = $class->getAttributes(DaprType::class);
+            if ( ! empty($attributes)) {
+                $type = $attributes[0]->newInstance()->type;
+            } else {
+                $type = $class->getShortName();
+            }
         }
         // end function
         $id = $this->get_id();
 
         DaprClient::delete(DaprClient::get_api("/actors/$type/$id/timers/$name"));
+
         return true;
     }
 }

--- a/src/lib/Actors/ActorProxy.php
+++ b/src/lib/Actors/ActorProxy.php
@@ -32,12 +32,11 @@ abstract class ActorProxy
         $type = $reflected_interface->getAttributes(DaprType::class)[0]?->newInstance()->type;
 
         if (empty($type)) {
-            throw new LogicException("$interface must have a DAPR_TYPE constant");
+            throw new LogicException("$interface must have a DaprType attribute");
         }
 
         $methods = $reflected_interface->getMethods(ReflectionMethod::IS_PUBLIC);
 
-        $proxy->DAPR_TYPE = $type;
         foreach ($methods as $method) {
             $method_name = $method->getName();
             switch ($method_name) {

--- a/src/lib/Actors/ActorProxy.php
+++ b/src/lib/Actors/ActorProxy.php
@@ -6,7 +6,6 @@ use Dapr\DaprClient;
 use Dapr\Serializer;
 use LogicException;
 use ReflectionClass;
-use ReflectionClassConstant;
 use ReflectionMethod;
 
 /**
@@ -15,6 +14,90 @@ use ReflectionMethod;
  */
 abstract class ActorProxy
 {
+    public static int $mode = ProxyModes::GENERATED;
+
+    public static function generate_proxy_class($interface)
+    {
+        $reflected_interface = new ReflectionClass($interface);
+        $type                = $reflected_interface->getAttributes(DaprType::class)[0]?->newInstance()->type;
+
+        if (empty($type)) {
+            throw new LogicException("$interface must have a DaprType attribute");
+        }
+
+        return self::_generate_proxy_class($reflected_interface, $interface, $type);
+    }
+
+    private static function _generate_proxy_class(
+        ReflectionClass $reflected_interface,
+        string $interface,
+        string $type
+    ): string {
+        ['full' => $full_proxy_type, 'simple' => $proxy_type] = self::get_proxy_type($type);
+        if (self::$mode === ProxyModes::GENERATED_CACHED) {
+            $file = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$proxy_type.'.php';
+            if (file_exists($file)) {
+                require_once($file);
+                if (class_exists($full_proxy_type)) {
+                    return '';
+                }
+            }
+        }
+
+        $methods          = $reflected_interface->getMethods(ReflectionMethod::IS_PUBLIC);
+        $rendered_methods = [];
+        foreach ($methods as $method) {
+            $method_name = $method->getName();
+            switch ($method_name) {
+                case 'get_id':
+                    $rendered_methods[] = <<<METHOD
+    public function get_id(): mixed {
+        return \$this->id;
+    }
+METHOD;
+                    break;
+                case 'remind':
+                case 'on_activation':
+                case 'on_deactivation':
+                    $rendered_methods[] = self::generate_failure_method($method);
+                    break;
+                case 'delete_timer':
+                case 'create_timer':
+                case 'delete_reminder':
+                case 'get_reminder':
+                case 'create_reminder':
+                    break;
+                default:
+                    $rendered_methods[] = self::generate_proxy_method($method);
+                    break;
+            }
+        }
+        $rendered_methods = implode("\n", $rendered_methods);
+        $class            = <<<CLASS
+namespace Dapr\Proxies;
+#[\Dapr\Actors\DaprType('$type')]
+class $proxy_type extends \Dapr\Actors\InternalProxy implements \\$interface {
+    public \$id;
+    use \Dapr\Actors\Actor;
+
+$rendered_methods
+}
+CLASS;
+        if (self::$mode === ProxyModes::GENERATED_CACHED) {
+            file_put_contents($file, "<?php\n\n".$class);
+        }
+
+        return $class;
+    }
+
+    private static function get_proxy_type(string $dapr_type)
+    {
+        $internal_type = preg_replace('/[^a-zA-Z0-9_]*/', '', $dapr_type);
+        $proxy_type    = 'dapr_proxy_'.$internal_type;
+
+        return ['full' => "\\Dapr\\Proxies\\$proxy_type", 'simple' => $proxy_type];
+    }
+
     /**
      * Returns an actor proxy
      *
@@ -27,49 +110,172 @@ abstract class ActorProxy
     public static function get(string $interface, $id)
     {
         $reflected_interface = new ReflectionClass($interface);
-        $proxy               = new InternalProxy();
-
-        $type = $reflected_interface->getAttributes(DaprType::class)[0]?->newInstance()->type;
+        $type                = ($reflected_interface->getAttributes(DaprType::class)[0] ?? null)?->newInstance()->type;
 
         if (empty($type)) {
             throw new LogicException("$interface must have a DaprType attribute");
         }
 
-        $methods = $reflected_interface->getMethods(ReflectionMethod::IS_PUBLIC);
+        ['full' => $full_type] = self::get_proxy_type($type);
+        switch (self::$mode) {
+            case ProxyModes::GENERATED_CACHED:
+            case ProxyModes::GENERATED:
+                if ( ! class_exists($full_type)) {
+                    eval(self::_generate_proxy_class($reflected_interface, $interface, $type));
+                }
+                $proxy     = new $full_type();
+                $proxy->id = $id;
+                break;
+            case ProxyModes::DYNAMIC:
+                $proxy            = new InternalProxy();
+                $proxy->DAPR_TYPE = $type;
+                foreach ($reflected_interface->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+                    $method_name = $method->getName();
+                    switch ($method_name) {
+                        case 'get_id':
+                            $proxy->$method_name = function () use ($id) {
+                                return $id;
+                            };
+                            break;
+                        case 'remind':
+                        case 'on_activation':
+                        case 'on_deactivation':
+                            $proxy->$method_name = function () use ($method_name) {
+                                throw new LogicException("Cannot call $method_name from outside the actor.");
+                            };
+                            break;
+                        case 'delete_timer':
+                        case 'create_timer':
+                        case 'delete_reminder':
+                        case 'get_reminder':
+                        case 'create_reminder':
+                            break;
+                        default:
+                            $proxy->$method_name = function (...$params) use ($type, $id, $method_name) {
+                                $result = DaprClient::post(
+                                    DaprClient::get_api("/actors/$type/$id/method/$method_name"),
+                                    Serializer::as_json($params)
+                                );
 
-        foreach ($methods as $method) {
-            $method_name = $method->getName();
-            switch ($method_name) {
-                case 'get_id':
-                    $proxy->$method_name = function () use ($id) {
-                        return $id;
-                    };
-                    break;
-                case 'remind':
-                case 'on_activation':
-                case 'on_deactivation':
-                    $proxy->$method_name = function () use ($method_name) {
-                        throw new LogicException("Cannot call $method_name from outside the actor.");
-                    };
-                    break;
-                case 'delete_timer':
-                case 'create_timer':
-                case 'delete_reminder':
-                case 'get_reminder':
-                case 'create_reminder':
-                    break;
-                default:
-                    $proxy->$method_name = function (...$params) use ($type, $id, $method_name) {
-                        $result = DaprClient::post(
-                            DaprClient::get_api("/actors/$type/$id/method/$method_name"),
-                            Serializer::as_json($params)
-                        );
-                        return $result->data;
-                    };
-                    break;
-            }
+                                return $result->data;
+                            };
+                            break;
+                    }
+                }
+                break;
         }
 
         return $proxy;
+    }
+
+    private static function generate_failure_method(ReflectionMethod $method)
+    {
+        $signature = self::create_signature($method);
+
+        return <<<METHOD
+    public function $signature {
+        throw new \LogicException('Cannot call {$method->getName()} outside the actor.');
+    }
+METHOD;
+
+    }
+
+    private static function generate_proxy_method(ReflectionMethod $method)
+    {
+        $signature = self::create_signature($method);
+        $array     = self::params_to_array($method);
+        $return    = $method->getReturnType();
+        if ($return instanceof \ReflectionNamedType) {
+            $returns = $return->getName() !== 'void';
+        } else {
+            $returns = true;
+        }
+
+        if ($returns) {
+            $return = "return \$result->data;";
+        } else {
+            $return = '';
+        }
+
+        return <<<METHOD
+    public function $signature {
+        \$data = $array;
+        // inline function: get name
+        \$class = new \ReflectionClass(\$this);
+        \$attributes = \$class->getAttributes(\Dapr\Actors\DaprType::class);
+        if (!empty(\$attributes)) {
+            \$type = \$attributes[0]->newInstance()->type;
+        } else {
+            \$type = \$class->getShortName();
+        }
+        // end function
+        \$id = \$this->get_id(); 
+        \$result = \Dapr\DaprClient::post(
+            \Dapr\DaprClient::get_api("/actors/\$type/\$id/method/{$method->getName()}"),
+            \Dapr\Serializer::as_json(\$data)
+        );
+        $return
+    }
+METHOD;
+
+    }
+
+    private static function params_to_array(ReflectionMethod $method)
+    {
+        $params = $method->getParameters();
+        $array  = [];
+        foreach ($params as $param) {
+            $array[] = "'{$param->getName()}' => \${$param->getName()}";
+        }
+
+        return '['.implode(',', $array).']';
+    }
+
+    private static function render_param(\ReflectionParameter $param)
+    {
+        $name      = $param->getName();
+        $type_name = self::render_type($param->getType());
+        $default   = '';
+        if ($param->isDefaultValueAvailable()) {
+            $default = $param->getDefaultValue();
+            if (is_string($default)) {
+                $default = "'$default'";
+            }
+            $default = " = $default";
+        }
+
+        return "$type_name \$$name$default";
+    }
+
+    private static function render_type(\ReflectionType|null $type)
+    {
+        $type_name = '';
+        if ($type instanceof \ReflectionNamedType) {
+            $type_name = $type->isBuiltin() ? $type->getName() : '\\'.$type->getName();
+            $type_name = ($type->allowsNull() ? '?' : '').$type_name;
+        } elseif ($type instanceof \ReflectionUnionType) {
+            $type_name = [];
+            foreach ($type->getTypes() as $type) {
+                $type_name[] = self::render_type($type);
+            }
+            $type_name = implode('|', $type_name);
+        }
+
+        return $type_name;
+    }
+
+    private static function create_signature(ReflectionMethod $method)
+    {
+        $params          = $method->getParameters();
+        $return          = self::render_type($method->getReturnType());
+        $method_name     = $method->getName();
+        $rendered_params = [];
+        foreach ($params as $param) {
+            $rendered_params[] = self::render_param($param);
+        }
+        $rendered_params = implode(', ', $rendered_params);
+        $return          = empty($return) ? '' : ": $return";
+
+        return "$method_name($rendered_params)$return";
     }
 }

--- a/src/lib/Actors/ActorProxy.php
+++ b/src/lib/Actors/ActorProxy.php
@@ -29,7 +29,7 @@ abstract class ActorProxy
         $reflected_interface = new ReflectionClass($interface);
         $proxy               = new InternalProxy();
 
-        $type = (new ReflectionClassConstant($interface, 'DAPR_TYPE'))->getValue();
+        $type = $reflected_interface->getAttributes(DaprType::class)[0]?->newInstance()->type;
 
         if (empty($type)) {
             throw new LogicException("$interface must have a DAPR_TYPE constant");

--- a/src/lib/Actors/ActorRuntime.php
+++ b/src/lib/Actors/ActorRuntime.php
@@ -134,7 +134,7 @@ class ActorRuntime
         }
 
         $activation_tracker = hash('sha256', $description['dapr_type'].$description['id']);
-        $activation_tracker = rtrim(sys_get_temp_dir(), '/').'/dapr_'.$activation_tracker;
+        $activation_tracker = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'dapr_'.$activation_tracker;
 
         $is_activated = file_exists($activation_tracker);
 
@@ -218,8 +218,7 @@ class ActorRuntime
     {
         $reflected_type             = new ReflectionClass($actor_type);
         $attributes = $reflected_type->getAttributes(DaprType::class);
-        $dapr_type = $attributes[0] ?? null;
-        $dapr_type = $dapr_type?->newInstance()->type ?? $reflected_type->getShortName();
+        $dapr_type = ($attributes[0] ?? null)?->newInstance()->type ?? $reflected_type->getShortName();
         self::$actors[$dapr_type]   = $actor_type;
         self::$config['entities'][] = $dapr_type;
     }

--- a/src/lib/Actors/ActorRuntime.php
+++ b/src/lib/Actors/ActorRuntime.php
@@ -191,7 +191,7 @@ class ActorRuntime
     }
 
     /**
-     * Read a given type for a constant with the name STATE_TYPE.
+     * Read a state type from attributes
      *
      * @param string $type The type to read from.
      *
@@ -204,7 +204,7 @@ class ActorRuntime
 
             return $reflection->getAttributes(ActorState::class)[0]?->newInstance();
         } catch (Exception $ex) {
-            throw new \LogicException("Actor $type is using actor state, but is missing a STATE_TYPE const");
+            throw new \LogicException("Actor $type is using actor state, but is not properly configured.");
         }
     }
 

--- a/src/lib/Actors/ActorRuntime.php
+++ b/src/lib/Actors/ActorRuntime.php
@@ -9,7 +9,6 @@ use Dapr\Serializer;
 use Exception;
 use JetBrains\PhpStorm\ArrayShape;
 use ReflectionClass;
-use ReflectionClassConstant;
 
 /**
  * The Actor Runtime
@@ -87,8 +86,8 @@ class ActorRuntime
 
         try {
             $reflection = new ReflectionClass($description['type']);
-            $traits     = $reflection->getTraitNames();
-            $has_state  = in_array('Dapr\Actors\ActorState', $traits);
+            $attributes = $reflection->getAttributes(ActorState::class);
+            $has_state  = ! empty($attributes);
             $is_actor   = $reflection->implementsInterface('Dapr\Actors\IActor')
                           && $reflection->isInstantiable() && $reflection->isUserDefined();
         } catch (\ReflectionException $ex) {
@@ -118,9 +117,9 @@ class ActorRuntime
             $state = InternalActorState::begin_actor(
                 $description['dapr_type'],
                 $description['id'],
-                $state_config['type'],
-                $state_config['store'],
-                new $state_config['consistency']
+                $state_config->type,
+                $state_config->store,
+                new $state_config->consistency
             );
 
             /**
@@ -180,7 +179,7 @@ class ActorRuntime
 
         if ($has_state) {
             try {
-                InternalActorState::commit($state, $state_config['metadata'] ?? []);
+                InternalActorState::commit($state, $state_config->metadata ?? []);
             } catch (DaprException $ex) {
                 trigger_error($ex->getMessage(), E_USER_WARNING);
 
@@ -196,16 +195,14 @@ class ActorRuntime
      *
      * @param string $type The type to read from.
      *
-     * @return mixed The state type definition.
-     *
-     * @psalm-return array<array-key, scalar>|null|scalar
+     * @return ActorState The state type definition
      */
-    private static function get_state_type(string $type): mixed
+    private static function get_state_type(string $type): ActorState
     {
         try {
-            $reflection = new ReflectionClassConstant($type, 'STATE_TYPE');
+            $reflection = new ReflectionClass($type);
 
-            return $reflection->getValue();
+            return $reflection->getAttributes(ActorState::class)[0]?->newInstance();
         } catch (Exception $ex) {
             throw new \LogicException("Actor $type is using actor state, but is missing a STATE_TYPE const");
         }
@@ -217,8 +214,12 @@ class ActorRuntime
      * @param string $dapr_type The Dapr type
      * @param string $actor_type The actor to initialize when invoked
      */
-    public static function register_actor(string $dapr_type, string $actor_type): void
+    public static function register_actor(string $actor_type): void
     {
+        $reflected_type             = new ReflectionClass($actor_type);
+        $attributes = $reflected_type->getAttributes(DaprType::class);
+        $dapr_type = $attributes[0] ?? null;
+        $dapr_type = $dapr_type?->newInstance()->type ?? $reflected_type->getShortName();
         self::$actors[$dapr_type]   = $actor_type;
         self::$config['entities'][] = $dapr_type;
     }

--- a/src/lib/Actors/ActorState.php
+++ b/src/lib/Actors/ActorState.php
@@ -2,10 +2,17 @@
 
 namespace Dapr\Actors;
 
-/**
- * Trait ActorState
- * @package Dapr
- */
-trait ActorState
+use Attribute;
+use Dapr\consistency\StrongFirstWrite;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class ActorState
 {
+    public function __construct(
+        public string $store,
+        public string $type,
+        public string $consistency = StrongFirstWrite::class,
+        public array $metadata = []
+    ) {
+    }
 }

--- a/src/lib/Actors/DaprType.php
+++ b/src/lib/Actors/DaprType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Dapr\Actors;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class DaprType
+{
+    public function __construct(public string $type)
+    {
+    }
+}

--- a/src/lib/Actors/InternalProxy.php
+++ b/src/lib/Actors/InternalProxy.php
@@ -4,7 +4,6 @@ namespace Dapr\Actors;
 
 /**
  * Class InternalProxy
- * @property mixed DAPR_TYPE The dapr actor type
  * @package Dapr
  */
 class InternalProxy

--- a/src/lib/Actors/ProxyModes.php
+++ b/src/lib/Actors/ProxyModes.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dapr\Actors;
+
+abstract class ProxyModes {
+    public const GENERATED = 0;
+    public const GENERATED_CACHED = 1;
+    public const DYNAMIC = 2;
+}

--- a/tests/ActorTest.php
+++ b/tests/ActorTest.php
@@ -11,7 +11,7 @@ class ActorTest extends DaprTests
     public function testActorInvoke()
     {
         $id = uniqid();
-        ActorRuntime::register_actor('ActorClass', ActorClass::class);
+        ActorRuntime::register_actor( ActorClass::class);
         $this->inject_state(['value'], $id);
         $this->assertState(
             [
@@ -21,7 +21,7 @@ class ActorTest extends DaprTests
         );
         $this->set_body(['new value']);
         $result = ActorRuntime::handle_invoke(
-            ActorRuntime::extract_parts_from_request('PUT', "/actors/ActorClass/$id/method/a_function")
+            ActorRuntime::extract_parts_from_request('PUT', "/actors/TestActor/$id/method/a_function")
         );
         $this->assertSame(200, $result['code']);
         $this->assertTrue(\Dapr\Deserializer::maybe_deserialize(json_decode($result['body'])));
@@ -42,7 +42,7 @@ class ActorTest extends DaprTests
             code: 200,
             response_data: $state,
             expected_request: [
-                'keys'        => ["ActorClass||$id||value"],
+                'keys'        => ["TestActor||$id||value"],
                 'parallelism' => 10,
             ]
         );
@@ -63,13 +63,13 @@ class ActorTest extends DaprTests
                 ];
             }
         }
-        \Dapr\DaprClient::register_post("/actors/ActorClass/$id/state", 201, [], $return);
+        \Dapr\DaprClient::register_post("/actors/TestActor/$id/state", 201, [], $return);
     }
 
     public function testActorRuntime()
     {
         $id = uniqid();
-        ActorRuntime::register_actor('ActorClass', ActorClass::class);
+        ActorRuntime::register_actor( ActorClass::class);
         $this->inject_state(['value'], $id);
         $this->assertState(
             [
@@ -78,7 +78,7 @@ class ActorTest extends DaprTests
             $id
         );
         $this->set_body(['new value']);
-        $result = \Dapr\Runtime::get_handler_for_route('PUT', "/actors/ActorClass/$id/method/a_function")();
+        $result = \Dapr\Runtime::get_handler_for_route('PUT', "/actors/TestActor/$id/method/a_function")();
         $this->assertSame(200, $result['code']);
         $this->assertTrue(\Dapr\Deserializer::maybe_deserialize(json_decode($result['body'])));
     }
@@ -88,13 +88,13 @@ class ActorTest extends DaprTests
         $id = uniqid();
 
         /**
-         * @var \Fixtures\ActorInterface $proxy
+         * @var \Fixtures\ITestActor $proxy
          */
-        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ActorInterface::class, $id);
+        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ITestActor::class, $id);
 
         $this->assertSame($id, $proxy->get_id());
         \Dapr\DaprClient::register_get(
-            "/actors/ActorClass/$id/reminders/reminder",
+            "/actors/TestActor/$id/reminders/reminder",
             200,
             [
                 "dueTime" => '1s',
@@ -108,7 +108,7 @@ class ActorTest extends DaprTests
         $this->assertSame([0], $reminder->data);
 
         \Dapr\DaprClient::register_post(
-            "/actors/ActorClass/$id/timers/timer",
+            "/actors/TestActor/$id/timers/timer",
             200,
             [],
             [
@@ -123,7 +123,7 @@ class ActorTest extends DaprTests
         );
 
         \Dapr\DaprClient::register_post(
-            "/actors/ActorClass/$id/reminders/reminder",
+            "/actors/TestActor/$id/reminders/reminder",
             200,
             [],
             [
@@ -138,14 +138,14 @@ class ActorTest extends DaprTests
             )
         );
 
-        \Dapr\DaprClient::register_delete("/actors/ActorClass/$id/timers/timer", 204);
+        \Dapr\DaprClient::register_delete("/actors/TestActor/$id/timers/timer", 204);
         $proxy->delete_timer('timer');
 
-        \Dapr\DaprClient::register_delete("/actors/ActorClass/$id/reminders/reminder", 204);
+        \Dapr\DaprClient::register_delete("/actors/TestActor/$id/reminders/reminder", 204);
         $proxy->delete_reminder('reminder');
 
         \Dapr\DaprClient::register_post(
-            "/actors/ActorClass/$id/method/a_function",
+            "/actors/TestActor/$id/method/a_function",
             200,
             [],
             [
@@ -160,9 +160,9 @@ class ActorTest extends DaprTests
         $id = uniqid();
 
         /**
-         * @var \Fixtures\ActorInterface $proxy
+         * @var \Fixtures\ITestActor $proxy
          */
-        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ActorInterface::class, $id);
+        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ITestActor::class, $id);
         $this->expectException(LogicException::class);
         $proxy->on_activation();
     }
@@ -172,9 +172,9 @@ class ActorTest extends DaprTests
         $id = uniqid();
 
         /**
-         * @var \Fixtures\ActorInterface $proxy
+         * @var \Fixtures\ITestActor $proxy
          */
-        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ActorInterface::class, $id);
+        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ITestActor::class, $id);
         $this->expectException(LogicException::class);
         $proxy->on_deactivation();
     }
@@ -184,9 +184,9 @@ class ActorTest extends DaprTests
         $id = uniqid();
 
         /**
-         * @var \Fixtures\ActorInterface $proxy
+         * @var \Fixtures\ITestActor $proxy
          */
-        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ActorInterface::class, $id);
+        $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ITestActor::class, $id);
         $this->expectException(LogicException::class);
         $proxy->remind('', '');
     }

--- a/tests/ActorTest.php
+++ b/tests/ActorTest.php
@@ -5,6 +5,7 @@ use Fixtures\ActorClass;
 
 require_once __DIR__.'/DaprTests.php';
 require_once __DIR__.'/Fixtures/Actor.php';
+require_once __DIR__.'/Fixtures/BrokenActor.php';
 
 class ActorTest extends DaprTests
 {
@@ -145,11 +146,11 @@ class ActorTest extends DaprTests
         $proxy->delete_reminder('reminder');
 
         \Dapr\DaprClient::register_post(
-            "/actors/TestActor/$id/method/a_function",
-            200,
-            [],
-            [
-                null,
+            path: "/actors/TestActor/$id/method/a_function",
+            code: 200,
+            response_data: true,
+            expected_request: [
+                'value' => null,
             ]
         );
         $proxy->a_function(null);
@@ -189,5 +190,12 @@ class ActorTest extends DaprTests
         $proxy = \Dapr\Actors\ActorProxy::get(\Fixtures\ITestActor::class, $id);
         $this->expectException(LogicException::class);
         $proxy->remind('', '');
+    }
+
+    public function testNoDaprType() {
+        $id = uniqid();
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('IBrokenActor must have a DaprType attribute');
+        $proxy = \Dapr\Actors\ActorProxy::get(IBrokenActor::class, $id);
     }
 }

--- a/tests/Fixtures/Actor.php
+++ b/tests/Fixtures/Actor.php
@@ -3,32 +3,28 @@
 namespace Fixtures;
 
 use Dapr\Actors\Actor;
+use Dapr\Actors\ActorState;
+use Dapr\Actors\DaprType;
 use Dapr\Actors\IActor;
 use Dapr\consistency\StrongLastWrite;
 use Dapr\State\State;
 
-interface ActorInterface extends IActor
+#[DaprType('TestActor')]
+interface ITestActor extends IActor
 {
-    public const DAPR_TYPE = 'ActorClass';
-
     public function a_function($value): bool;
 }
 
-class ActorState extends State
+class TestActorState extends State
 {
     public string $value = "";
 }
 
-class ActorClass implements ActorInterface
+#[DaprType('TestActor')]
+#[ActorState('store', TestActorState::class)]
+class ActorClass implements ITestActor
 {
     use Actor;
-    use \Dapr\Actors\ActorState;
-
-    public const STATE_TYPE = [
-        'store'       => 'store',
-        'type'        => ActorState::class,
-        'consistency' => StrongLastWrite::class,
-    ];
 
     /**
      * ActorClass constructor.

--- a/tests/Fixtures/BrokenActor.php
+++ b/tests/Fixtures/BrokenActor.php
@@ -1,0 +1,9 @@
+<?php
+
+use Dapr\Actors\IActor;
+
+interface IBrokenActor extends IActor {}
+
+class BrokenActor {
+
+}

--- a/tests/Mocks/DaprClient.php
+++ b/tests/Mocks/DaprClient.php
@@ -23,29 +23,29 @@ class DaprClient
 
     public static function get(string $url): DaprResponse
     {
-        self::validate('GET', $url);
+        self::validate('GET', $url, '');
         $next = array_shift(self::$responses['GET'][$url]);
         if ($next === null) {
-            self::report_unregistered('GET', $url);
+            self::report_unregistered('GET', $url, '');
         }
         self::clean('GET', $url);
 
         return $next;
     }
 
-    private static function validate(string $method, string $url)
+    private static function validate(string $method, string $url, string $body)
     {
         if ( ! isset(self::$responses[$method])) {
-            self::report_unregistered($method, $url);
+            self::report_unregistered($method, $url, $body);
         }
         if ( ! isset(self::$responses[$method][$url])) {
-            self::report_unregistered($method, $url);
+            self::report_unregistered($method, $url, $body);
         }
     }
 
-    private static function report_unregistered(string $method, string $url)
+    private static function report_unregistered(string $method, string $url, string $body)
     {
-        throw new \Exception('unregistered '.$method.' performed on '.$url);
+        throw new \Exception('unregistered '.$method.' performed on '.$url."\n$body");
     }
 
     private static function clean(string $method, string $url)
@@ -68,10 +68,10 @@ class DaprClient
 
     public static function post(string $url, array $data): DaprResponse
     {
-        self::validate('POST', $url);
+        self::validate('POST', $url, json_encode($data, JSON_PRETTY_PRINT));
         $next = array_shift(self::$responses['POST'][$url]);
         if ($next === null) {
-            self::report_unregistered('POST', $url);
+            self::report_unregistered('POST', $url, json_encode($data, JSON_PRETTY_PRINT));
         }
         self::clean('POST', $url);
         if (is_callable($next['cleaner'])) {
@@ -101,10 +101,10 @@ class DaprClient
 
     public static function delete(string $url): DaprResponse
     {
-        self::validate('DELETE', $url);
+        self::validate('DELETE', $url, '');
         $next = array_shift(self::$responses['DELETE'][$url]);
         if ($next === null) {
-            self::report_unregistered('DELETE', $url);
+            self::report_unregistered('DELETE', $url, '');
         }
         self::clean('DELETE', $url);
 

--- a/tests/RuntimeTest.php
+++ b/tests/RuntimeTest.php
@@ -8,14 +8,14 @@ class RuntimeTest extends DaprTests
 {
     public function testConfig()
     {
-        ActorRuntime::register_actor('test', 'test');
+        ActorRuntime::register_actor(\Fixtures\ActorClass::class);
         ActorRuntime::set_drain_timeout(new DateInterval('PT10S'));
         ActorRuntime::set_idle_timeout(new DateInterval('PT10M'));
         ActorRuntime::set_scan_interval(new DateInterval('PT5S'));
         ActorRuntime::do_drain_actors(true);
         $expected_config = [
             'entities'                => [
-                'test',
+                'TestActor',
             ],
             'drainOngoingCallTimeout' => '0h0m10s0us',
             'actorIdleTimeout'        => '0h10m0s0us',


### PR DESCRIPTION
# Description

This is a breaking change that uses attributes instead of magic consts for actor configuration.

## Migration instructions:

1. Use `DaprType` on interfaces

- Remove the `DAPR_TYPE` const from the interface.
- Add `#[DaprType('my-actor-type')]` attribute to the interface.

2. Use `DaprType` attribute on the actor class.

By default, the name of the class will be used, however, you can specify the actor type which is needed in the event you're using namespaces.

3. `register_actor()` now only takes a single argument, the class to instantiate. The actor name is defined using the `DaprType` attribute on the actor class.
4. `STATE_TYPE` const now does nothing and the `ActorState` trait has been replaced with an `ActorState` attribute.
See the readme for documentation.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #12 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
