### PR TITLE
Fixes falsy serialization

### DIFF
--- a/src/lib/Serialization/Serializer.php
+++ b/src/lib/Serialization/Serializer.php
@@ -67,7 +67,10 @@ final class Serializer
                     $reflection_class = new \ReflectionClass($type_name);
                 }
                 foreach ($value as $prop => $prop_value) {
-                    if (empty($prop_value) && isset($reflection_class) && $reflection_class->hasProperty($prop)) {
+                    if (is_array($prop_value)
+                        && empty($prop_value)
+                        && isset($reflection_class)
+                        && $reflection_class->hasProperty($prop)) {
                         $attrs = $reflection_class->getProperty($prop)->getAttributes(AlwaysObject::class);
                         if (isset($attrs[0])) {
                             $obj[$prop] = new \stdClass();

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -41,6 +41,11 @@ final class SerializerTest extends TestCase
             public $emptyObj = [];
         };
 
+        $falsy_obj = new class {
+            public $emptyString = '';
+            public $false = false;
+        };
+
         $empty_class_as_array = new class {
         };
         $empty_class_as_obj   = new #[AlwaysObject] class {
@@ -93,6 +98,16 @@ JSON
             ],
             'Empty Class as Array'  => [$empty_class_as_array, '[]'],
             'Empty Class as Object' => [$empty_class_as_obj, '{}'],
+            'Falsy values'          => [
+                $falsy_obj,
+                <<<JSON
+{
+    "emptyString": "",
+    "false": false
+}
+JSON
+    ,
+            ],
         ];
     }
 
@@ -114,7 +129,7 @@ JSON
                 'message'   => 'testing',
                 'errorCode' => 'Exception',
                 'file'      => __FILE__,
-                'line'      => 111,
+                'line'      => 123,
                 'inner'     => null,
             ],
             $serialized

--- a/tests/SerializerTest.php
+++ b/tests/SerializerTest.php
@@ -129,7 +129,7 @@ JSON
                 'message'   => 'testing',
                 'errorCode' => 'Exception',
                 'file'      => __FILE__,
-                'line'      => 123,
+                'line'      => 126,
                 'inner'     => null,
             ],
             $serialized


### PR DESCRIPTION
# Description

When a value in an object can be falsy (empty string or false), it gets serialized into an empty array.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
