### PR TITLE
Uncomment empty subject check

### DIFF
--- a/src/index.php
+++ b/src/index.php
@@ -420,15 +420,16 @@ function test_pubsub(): void
     unlink('/tmp/sub-received');
     //unset($event->time);
     $event->topic      = "test";
-    $event->pubsubname = "pubsub";
+    $event->pubsub_name = "pubsub";
     echo "Expecting this data:\n";
     echo json_encode(json_decode($event->to_json()), JSON_PRETTY_PRINT)."\n";
     $received = CloudEvent::parse($raw_event);
+    unset($received->trace_id);
     echo json_encode(json_decode($received->to_json()), JSON_PRETTY_PRINT)."\n";
     assert_equals(
         $event->to_json(),
         $received->to_json(),
-        'Event should be the same event we sent.'
+        'Event should be the same event we sent, minus the trace id.'
     );
 
     echo "\n\nPublishing raw event";

--- a/src/lib/PubSub/CloudEvent.php
+++ b/src/lib/PubSub/CloudEvent.php
@@ -96,6 +96,21 @@ class CloudEvent
      */
     public $data;
 
+    /**
+     * @var string|null The trace id
+     */
+    public ?string $trace_id;
+
+    /**
+     * @var string|null The topic
+     */
+    public ?string $topic;
+
+    /**
+     * @var string|null The name of the pubsub
+     */
+    public ?string $pubsub_name;
+
     public function __construct()
     {
     }
@@ -116,6 +131,9 @@ class CloudEvent
         $event->type              = (string)$raw['type'];
         $event->data_content_type = $raw['datacontenttype'] ?? null;
         $event->subject           = $raw['subject'] ?? null;
+        $event->pubsub_name       = $raw['pubsubname'] ?? null;
+        $event->topic             = $raw['topic'] ?? null;
+        $event->trace_id          = $raw['traceid'] ?? null;
         $time                     = $raw['time'] ?? null;
         if ( ! empty($time)) {
             $event->time = new \DateTime($time);
@@ -131,6 +149,7 @@ class CloudEvent
     public function to_json(): string|bool
     {
         Runtime::$logger?->debug('Serializing cloud event');
+
         return json_encode($this->to_array());
     }
 
@@ -158,6 +177,9 @@ class CloudEvent
         if (isset($this->data)) {
             $json['data'] = $this->data;
         }
+        if (isset($this->trace_id)) {
+            $json['traceid'] = $this->trace_id;
+        }
 
         return $json;
     }
@@ -184,11 +206,9 @@ class CloudEvent
             return false;
         }
 
-        // for non-custom events, the subject is an empty string
-        /*
         if (isset($this->subject) && empty($this->subject)) {
             return false;
-        }*/
+        }
 
         return true;
     }


### PR DESCRIPTION
# Description

In a priort v1.0.0-rc.3, there was an empty `source` in cloud events. This caused an issue with validation. This adds the validation back and the extra, new information from the cloud event.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
