### PR TITLE
Add timeout to workflows

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@2.9.0
@@ -42,7 +42,7 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
   lint:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@2.9.0
@@ -72,7 +72,7 @@ jobs:
         run: composer run-script lint
   integration-tests:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@2.9.0


### PR DESCRIPTION
# Description

Adds a default timeout of 5 minutes for all workflows (which is more than enough time)
