### PR TITLE
Add hugo based docs

### DIFF
--- a/daprdocs/content/en/php-sdk-docs/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/_index.md
@@ -1,0 +1,102 @@
+---
+type: docs 
+title: "Dapr PHP SDK"
+linkTitle: "PHP"
+weight: 1000 
+description: PHP SDK packages for developing Dapr applications 
+no_list: true
+---
+
+Dapr offers an SDK to help with the development of PHP applications. Using it, you can create PHP clients, servers, and virtual actors with Dapr.
+
+## Setting up
+
+### Prerequisites
+
+- [Composer](https://getcomposer.org/)
+- [PHP 8](https://www.php.net/)
+
+### Optional Prerequisites
+
+- [Docker](https://www.docker.com/)
+- [xdebug](http://xdebug.org/) -- for debugging
+
+## Initialize your project
+
+In a directory where you want to create your service, run `composer init` and answer the questions.
+Install `dapr/php-sdk` and any other dependencies you may wish to use.
+
+## Configure your service
+
+Create a config.php, copying the contents below:
+
+```php
+<?php
+
+use Dapr\Actors\Generators\ProxyFactory;
+use function DI\env;
+
+return [
+    // Generate a new proxy on each request - recommended for development
+    'dapr.actors.proxy.generation' => ProxyFactory::GENERATED,
+    
+    // put any subscriptions here
+    'dapr.subscriptions'           => [],
+    
+    // if this service will be hosting any actors, add them here
+    'dapr.actors'                  => [],
+    
+    // if this service will be hosting any actors, configure how long until dapr should consider an actor idle
+    'dapr.actors.idle_timeout'     => null,
+    
+    // if this service will be hosting any actors, configure how often dapr will check for idle actors 
+    'dapr.actors.scan_interval'    => null,
+    
+    // if this service will be hosting any actors, configure how long dapr will wait for an actor to finish during drains
+    'dapr.actors.drain_timeout'    => null,
+    
+    // if this service will be hosting any actors, configure if dapr should wait for an actor to finish
+    'dapr.actors.drain_enabled'    => null,
+    
+    // you shouldn't have to change this, but the setting is here if you need to
+    'dapr.port'                    => env('DAPR_HTTP_PORT', '3500'),
+    
+    // add any custom serialization routines here
+    'dapr.serializers.custom'      => [],
+    
+    // add any custom deserialization routines here
+    'dapr.deserializers.custom'    => [],
+];
+```
+
+## Create your service
+
+Create `index.php` and put the following contents:
+
+```php
+<?php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+use Dapr\App;
+
+$app = App::create(configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions(__DIR__ . '/config.php'));
+$app->get('/hello/{name}', function(string $name) {
+    return ['hello' => $name];
+});
+$app->start();
+```
+
+## Try it out
+
+Initialize dapr with `dapr init` and then start the project with `dapr run -a dev -p 3000 -- php -S 0.0.0.0:3000`.
+
+You can now open a web browser and point it to [http://localhost:3000/hello/world](http://localhost:3000/hello/world)
+replacing `world` with your name, a pet's name, or whatever you want.
+
+Congratulations, you've created your first Dapr service! I'm excited to see what you'll do with it!
+
+## More Information
+
+- [Packagist](https://packagist.org/packages/dapr/php-sdk)
+- [Dapr SDK serialization]({{< ref sdk-serialization.md >}})

--- a/daprdocs/content/en/php-sdk-docs/php-actors/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-actors/_index.md
@@ -1,0 +1,160 @@
+---
+type: docs
+title: "Virtual Actors"
+linkTitle: "Actors"
+weight: 1000
+description: How to build actors
+no_list: true
+---
+
+If you're new to the actor pattern, the best place to learn about the actor pattern is in
+the [Actor Overview.]({{< ref actors-overview.md >}})
+
+In the PHP SDK, there are two sides to an actor, the Client, and the Actor (aka, the Runtime). As a client of an actor,
+you'll interact with a remote actor via the `ActorProxy` class. This class generates a proxy class on-the-fly using one
+of several configured strategies.
+
+When writing an actor, state can be managed for you. You can hook into the actor lifecycle, and define reminders and
+timers. This gives you considerable power for handling all types of problems that the actor pattern is suited for.
+
+## The Actor Proxy
+
+Whenever you want to communicate with an actor, you'll need to get a proxy object to do so. The proxy is responsible for
+serializing your request, deserializing the response, and returning it to you, all while obeying the contract defined by
+the specified interface.
+
+In order to create the proxy, you'll first need an interface to define how and what you send and receive from an actor.
+For example, if you want to communicate with a counting actor that solely keeps track of counts, you might define the
+interface as follows:
+
+```php
+#[\Dapr\Actors\Attributes\DaprType('Counter')]
+interface ICount {
+    function increment(int $amount = 1): void;
+    function get_count(): int;
+}
+```
+
+It's a good idea to put this interface in a shared library that the actor and clients can both access (if both are written in PHP). The `DaprType`
+attribute tells the DaprClient the name of the actor to send to. It should match the implementation's `DaprType`, though
+you can override the type if needed.
+
+```php
+$app->run(function(\Dapr\Actors\ActorProxy $actorProxy) {
+    $actor = $actorProxy->get(ICount::class, 'actor-id');
+    $actor->increment(10);
+});
+```
+
+## Writing Actors
+
+To create an actor, you need to implement the interface you defined earlier and also add the `DaprType` attribute. All
+actors *must* implement `IActor`, however there's an `Actor` base class that implements the boilerplate making your
+implementation much simpler.
+
+Here's the counter actor:
+
+```php
+#[\Dapr\Actors\Attributes\DaprType('Count')]
+class Counter extends \Dapr\Actors\Actor implements ICount {
+    function __construct(string $id, private CountState $state) {
+        parent::__construct($id);
+    }
+    
+    function increment(int $amount = 1): void {
+        $this->state->count += $amount;
+    }
+    
+    function get_count(): int {
+        return $this->state->count;
+    }
+}
+```
+
+The most important bit is the constructor. It takes at least one argument with the name of `id` which is the id of the
+actor. Any additional arguments are injected by the DI container, including any `ActorState` you want to use.
+
+### Actor Lifecycle
+
+An actor is instantiated via the constructor on every request targeting that actor type. You can use it to calculate
+ephemeral state or handle any kind of request-specific startup you require, such as setting up other clients or
+connections.
+
+After the actor is instantiated, the `on_activation()` method may be called. The `on_activation()` method is called any
+time the actor "wakes up" or when it is created for the first time. It is not called on every request.
+
+Next, the actor method is called. This may be from a timer, reminder, or from a client. You may perform any work that
+needs to be done and/or throw an exception.
+
+Finally, the result of the work is returned to the caller. After some time (depending on how you've configured the
+service), the actor will be deactivated and `on_deactivation()` will be called. This may not be called if the host dies,
+daprd crashes, or some other error occurs which prevents it from being called successfully.
+
+## Actor State
+
+Actor state is a "Plain Old PHP Object" (POPO) that extends `ActorState`. The `ActorState` base class provides a couple
+of useful methods. Here's an example implementation:
+
+```php
+class CountState extends \Dapr\Actors\ActorState {
+    public int $count = 0;
+}
+```
+
+## Registering an Actor
+
+Dapr expects to know what actors a service may host at startup. You need to add it to the configuration:
+
+{{< tabs "Production" "Development" >}}
+
+{{% codetab %}}
+
+If you want to take advantage of pre-compiled dependency injection, you need to use a factory:
+
+```php
+<?php
+// in config.php
+
+return [
+    'dapr.actors' => fn() => [Counter::class],
+];
+```
+
+All that is required to start the app:
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$app = \Dapr\App::create(
+    configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions('config.php')->enableCompilation(__DIR__)
+);
+$app->start();
+```
+
+{{% /codetab %}}
+{{% codetab %}}
+
+```php
+<?php
+// in config.php
+
+return [
+    'dapr.actors' => [Counter::class]
+];
+```
+
+All that is required to start the app:
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$app = \Dapr\App::create(configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions('config.php'));
+$app->start();
+```
+
+{{% /codetab %}}
+{{< /tabs >}}

--- a/daprdocs/content/en/php-sdk-docs/php-actors/php-actor-reference.md
+++ b/daprdocs/content/en/php-sdk-docs/php-actors/php-actor-reference.md
@@ -1,0 +1,235 @@
+---
+type: docs
+title: "Actor Reference"
+linkTitle: "Reference"
+weight: 1000
+description: PHP Actor Reference 
+no_list: true
+---
+
+## Proxy modes
+
+There are four different modes actor proxies are handled. Each mode presents different trade-offs that you'll need to
+weigh during development and in production.
+
+```php
+\Dapr\Actors\Generators\ProxyFactory::GENERATED;
+\Dapr\Actors\Generators\ProxyFactory::GENERATED_CACHED;
+\Dapr\Actors\Generators\ProxyFactory::ONLY_EXISTING;
+\Dapr\Actors\Generators\ProxyFactory::DYNAMIC;
+```
+
+It can be set with `dapr.actors.proxy.generation` configuration key.
+
+{{< tabs "GENERATED" "GENERATED_CACHED" "ONLY_EXISTING" "DYNAMIC" >}}
+{{% codetab %}}
+
+This is the default mode. In this mode, a class is generated and `eval`'d on every request. It's mostly for development
+and shouldn't be used in production.
+
+{{% /codetab %}}
+{{% codetab %}}
+
+This is the same as `ProxyModes::GENERATED` except the class is stored in a tmp file so it doesn't need to be
+regenerated on every request. It doesn't know when to update the cached class, so using it in development is discouraged
+but is offered for when manually generating the files isn't possible.
+
+{{% /codetab %}}
+{{% codetab %}}
+
+In this mode, an exception is thrown if the proxy class doesn't exist. This is useful for when you don't want to use any
+generation of code in production. You'll have to make sure the class is generated and pre/autoloaded.
+
+{{% /codetab %}}
+{{% codetab %}}
+
+In this mode, the proxy satisfies the interface contract, however, it does not actually implement the interface itself
+(meaning `instanceof` will be `false`). This mode takes advantage of a few quirks in PHP to work and exists for cases
+where code cannot be `eval`'d or generated.
+
+{{% /codetab %}}
+{{< /tabs >}}
+
+### Generating proxies
+
+You can create a composer script to generate proxies on demand to take advantage of the `ONLY_EXISTING` mode. 
+
+Create a `ProxyCompiler.php`
+
+```php
+<?php
+
+class ProxyCompiler {
+    private const PROXIES = [
+        MyActorInterface::class,
+        MyOtherActorInterface::class,
+    ];
+    
+    private const PROXY_LOCATION = __DIR__.'/proxies/';
+    
+    public static function compile() {
+        try {
+            $app = \Dapr\App::create();
+            foreach(self::PROXIES as $interface) {
+                $output = $app->run(function(\DI\FactoryInterface $factory) use ($interface) {
+                    return \Dapr\Actors\Generators\FileGenerator::generate($interface, $factory);
+                });
+                $reflection = new ReflectionClass($interface);
+                $dapr_type = $reflection->getAttributes(\Dapr\Actors\Attributes\DaprType::class)[0]->newInstance()->type;
+                $filename = 'dapr_proxy_'.$dapr_type.'.php';
+                file_put_contents(self::PROXY_LOCATION.$filename, $output);
+                echo "Compiled: $interface";
+            }
+        } catch (Exception $ex) {
+            echo "Failed to generate proxy for $interface\n{$ex->getMessage()} on line {$ex->getLine()} in {$ex->getFile()}\n";
+        }
+    }
+}
+```
+
+Then add a psr-4 autoloader for the generated proxies and a script in `composer.json`:
+
+```json
+{
+  "autoload": {
+    "psr-4": {
+      "Dapr\\Proxies\\": "path/to/proxies"
+    }
+  },
+  "scripts": {
+    "compile-proxies": "ProxyCompiler::compile"
+  }
+}
+```
+
+And finally, configure dapr to only use the generated proxies:
+
+```php
+<?php
+// in config.php
+
+return [
+    'dapr.actors.proxy.generation' => ProxyFactory::ONLY_EXISTING,
+];
+```
+
+### Requests
+
+Creating an actor proxy is very inexpensive for any mode. There are no requests made when creating an actor proxy object.
+
+When you call a method on a proxy object, only methods that you implemented are serviced by your actor implementation. 
+`get_id()` is handled locally, and `get_reminder()`, `delete_reminder()`, etc. are handled by the `daprd`.
+
+## Actor implementation
+
+Every actor implementation in PHP must implement `\Dapr\Actors\IActor` and use the `\Dapr\Actors\ActorTrait` trait. This
+allows for fast reflection and some shortcuts. Using the `\Dapr\Actors\Actor` abstract base class does this for you, but
+if you need to override the default behavior, you can do so by implementing the interface and using the trait.
+
+## Activation and deactivation
+
+When an actor activates, a token file is written to a temporary directory (`'/tmp/dapr_' + sha256(concat(Dapr type, id))` by default).
+This is persisted until the actor deactivates, or the host shuts down. This allows for `on_activation` to be called once
+and only once when Dapr activates the actor on the host.
+
+## Performance
+
+Actor method invocation is very fast on a production setup with `php-fpm` and `nginx`. Even though the actor is constructed on
+every request, actor state keys are only loaded on-demand and not during each request. However, there is some overhead
+in loading each key individually. This can be mitigated by storing an array of data in state, trading some usability for speed. It
+is not recommended doing this from the start, but as an optimization when needed.
+
+## Versioning state
+
+The names of the variables in the `ActorState` object directly correspond to key names in the store. This means that if
+you change the type or name of a variable, you may run into errors. To get around this, you may need to version your state
+object. In order to do this, you'll need to override how state is loaded and stored. There are many ways to approach this,
+one such solution might be something like this:
+
+```php
+<?php
+
+class VersionedState extends \Dapr\Actors\ActorState {
+    /**
+     * @var int The current version of the state in the store. We give a default value of the current version. 
+     * However, it may be in the store with a different value. 
+     */
+    public int $state_version = self::VERSION;
+    
+    /**
+     * @var int The current version of the data
+     */
+    private const VERSION = 3;
+    
+    /**
+     * Call when your actor activates.
+     */
+    public function upgrade() {
+        if($this->state_version < self::VERSION) {
+            $value = parent::__get($this->get_versioned_key('key', $this->state_version));
+            // update the value after updating the data structure
+            parent::__set($this->get_versioned_key('key', self::VERSION), $value);
+            $this->state_version = self::VERSION;
+            $this->save_state();
+        }
+    }
+    
+    // if you upgrade all keys as needed in the method above, you don't need to walk the previous
+    // keys when loading/saving and you can just get the current version of the key.
+    
+    private function get_previous_version(int $version): int {
+        return $this->has_previous_version($version) ? $version - 1 : $version;
+    }
+    
+    private function has_previous_version(int $version): bool {
+        return $version >= 0;
+    }
+    
+    private function walk_versions(int $version, callable $callback, callable $predicate): mixed {
+        $value = $callback($version);
+        if($predicate($value) || !$this->has_previous_version($version)) {
+            return $value;
+        }
+        return $this->walk_versions($this->get_previous_version($version), $callback, $predicate);
+    }
+    
+    private function get_versioned_key(string $key, int $version) {
+        return $this->has_previous_version($version) ? $version.$key : $key;
+    }
+    
+    public function __get(string $key): mixed {
+        return $this->walk_versions(
+            self::VERSION, 
+            fn($version) => parent::__get($this->get_versioned_key($key, $version)),
+            fn($value) => isset($value)
+        );
+    }
+    
+    public function __isset(string $key): bool {
+        return $this->walk_versions(
+            self::VERSION,
+            fn($version) => parent::__isset($this->get_versioned_key($key, $version)),
+            fn($isset) => $isset
+        );
+    }
+    
+    public function __set(string $key,mixed $value): void {
+        // optional: you can unset previous versions of the key
+        parent::__set($this->get_versioned_key($key, self::VERSION), $value);
+    }
+    
+    public function __unset(string $key) : void {
+        // unset this version and all previous versions
+        $this->walk_versions(
+            self::VERSION, 
+            fn($version) => parent::__unset($this->get_versioned_key($key, $version)), 
+            fn() => false
+        );
+    }
+}
+```
+
+There's a lot to be optimized, and it wouldn't be a good idea to use this verbatim in production, but you can get the 
+gist of how it would work. A lot of it will depend on your use case which is why there's not something like this in 
+the SDK. For instance, in this example implementation, the previous value is kept for where there may be a bug during an upgrade; 
+keeping the previous value allows for running the upgrade again, but you may wish to delete the previous value. 

--- a/daprdocs/content/en/php-sdk-docs/php-actors/php-actor-reference.md
+++ b/daprdocs/content/en/php-sdk-docs/php-actors/php-actor-reference.md
@@ -1,9 +1,9 @@
 ---
 type: docs
-title: "Actor Reference"
-linkTitle: "Reference"
+title: "Production Reference: Actors"
+linkTitle: "Production Reference"
 weight: 1000
-description: PHP Actor Reference 
+description: Running PHP actors in production
 no_list: true
 ---
 
@@ -37,22 +37,12 @@ but is offered for when manually generating the files isn't possible.
 {{% /codetab %}}
 {{% codetab %}}
 
-In this mode, an exception is thrown if the proxy class doesn't exist. This is useful for when you don't want to use any
-generation of code in production. You'll have to make sure the class is generated and pre/autoloaded.
-
-{{% /codetab %}}
-{{% codetab %}}
-
-In this mode, the proxy satisfies the interface contract, however, it does not actually implement the interface itself
-(meaning `instanceof` will be `false`). This mode takes advantage of a few quirks in PHP to work and exists for cases
-where code cannot be `eval`'d or generated.
-
-{{% /codetab %}}
-{{< /tabs >}}
+In this mode, an exception is thrown if the proxy class doesn't exist. This is useful for when you don't want to 
+generate code in production. You'll have to make sure the class is generated and pre-/autoloaded.
 
 ### Generating proxies
 
-You can create a composer script to generate proxies on demand to take advantage of the `ONLY_EXISTING` mode. 
+You can create a composer script to generate proxies on demand to take advantage of the `ONLY_EXISTING` mode.
 
 Create a `ProxyCompiler.php`
 
@@ -113,6 +103,16 @@ return [
 ];
 ```
 
+{{% /codetab %}}
+{{% codetab %}}
+
+In this mode, the proxy satisfies the interface contract, however, it does not actually implement the interface itself
+(meaning `instanceof` will be `false`). This mode takes advantage of a few quirks in PHP to work and exists for cases
+where code cannot be `eval`'d or generated.
+
+{{% /codetab %}}
+{{< /tabs >}}
+
 ### Requests
 
 Creating an actor proxy is very inexpensive for any mode. There are no requests made when creating an actor proxy object.
@@ -128,16 +128,18 @@ if you need to override the default behavior, you can do so by implementing the 
 
 ## Activation and deactivation
 
-When an actor activates, a token file is written to a temporary directory (`'/tmp/dapr_' + sha256(concat(Dapr type, id))` by default).
+When an actor activates, a token file is written to a temporary directory (by default this is in 
+`'/tmp/dapr_' + sha256(concat(Dapr type, id))` in linux and `'%temp%/dapr_' + sha256(concat(Dapr type, id))` on Windows).
 This is persisted until the actor deactivates, or the host shuts down. This allows for `on_activation` to be called once
 and only once when Dapr activates the actor on the host.
 
 ## Performance
 
-Actor method invocation is very fast on a production setup with `php-fpm` and `nginx`. Even though the actor is constructed on
-every request, actor state keys are only loaded on-demand and not during each request. However, there is some overhead
-in loading each key individually. This can be mitigated by storing an array of data in state, trading some usability for speed. It
-is not recommended doing this from the start, but as an optimization when needed.
+Actor method invocation is very fast on a production setup with `php-fpm` and `nginx`, or IIS on Windows. Even though 
+the actor is constructed on every request, actor state keys are only loaded on-demand and not during each request. 
+However, there is some overhead in loading each key individually. This can be mitigated by storing an array of data in 
+state, trading some usability for speed. It is not recommended doing this from the start, but as an optimization when 
+needed.
 
 ## Versioning state
 

--- a/daprdocs/content/en/php-sdk-docs/php-app/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-app/_index.md
@@ -1,0 +1,48 @@
+---
+type: docs
+title: "The App"
+linkTitle: "App"
+weight: 1000
+description: Using the App Class
+no_list: true
+---
+
+In PHP, there is no default router. Thus, the `\Dapr\App` class is provided. It uses 
+[Nikic's FastRoute](https://github.com/nikic/FastRoute) under the hood. However, you are free to use any router or
+framework that you'd like. Just check out the `add_dapr_routes()` method in the `App` class to see how actors and
+subscriptions are implemented.
+
+Every app should start with `App::create()` which takes two parameters, the first is an existing DI container, if you
+have one, and the second is a callback to hook into the `ContainerBuilder` and add your own configuration.
+
+From there, you should define your routes and then call `$app->start()` to execute the route on the current request.
+
+
+```php
+<?php
+// app.php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$app = \Dapr\App::create(configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions('config.php'));
+
+// add a controller for GET /test/{id} that returns the id
+$app->get('/test/{id}', fn(string $id) => $id);
+
+$app->start();
+```
+
+## Using the app as a client
+
+When you just want to use Dapr as a client, such as in existing code, you can call `$app->run()`. In these cases, there's
+usually no need for a custom configuration, however, you may want to use a compiled DI container, especially in production:
+
+```php
+<?php
+// app.php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$app = \Dapr\App::create(configure: fn(\DI\ContainerBuilder $builder) => $builder->enableCompilation(__DIR__));
+$result = $app->run(fn(\Dapr\DaprClient $client) => $client->get('/invoke/other-app/method/my-method'));
+```

--- a/daprdocs/content/en/php-sdk-docs/php-app/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-app/_index.md
@@ -32,6 +32,24 @@ $app->get('/test/{id}', fn(string $id) => $id);
 $app->start();
 ```
 
+## Returning from a controller
+
+You can return anything from a controller, and it will be serialized into a json object. You can also request the
+Psr Response object and return that instead, allowing you to customize headers, and have control over the entire response:
+
+```php
+$app = \Dapr\App::create(configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions('config.php'));
+
+// add a controller for GET /test/{id} that returns the id
+$app->get('/test/{id}', 
+    fn(
+        string $id, 
+        \Psr\Http\Message\ResponseInterface $response, 
+        \Nyholm\Psr7\Factory\Psr17Factory $factory) => $response->withBody($factory->createStream($id)));
+
+$app->start();
+```
+
 ## Using the app as a client
 
 When you just want to use Dapr as a client, such as in existing code, you can call `$app->run()`. In these cases, there's

--- a/daprdocs/content/en/php-sdk-docs/php-app/php-unit-testing.md
+++ b/daprdocs/content/en/php-sdk-docs/php-app/php-unit-testing.md
@@ -1,0 +1,168 @@
+---
+type: docs
+title: "Unit Testing"
+linkTitle: "Unit Testing"
+weight: 1000
+description: Unit Testing
+no_list: true
+---
+
+Unit, functional, and integration tests are first-class citizens with the PHP SDK. Using the DI container, mocks, stubs,
+and the provided `\Dapr\Mocks\TestClient` allows you to have very fine-grained tests.
+
+## Testing Actors
+
+With actors, there are two things we're interested in while the actor is under test:
+
+1. The returned result based on an initial state
+2. The resulting state based on the initial state
+
+{{< tabs "integration test with TestClient" "unit test" >}}
+
+{{% codetab %}}
+
+Here's an example test a very simple actor that updates its state and returns a specific value:
+
+```php
+<?php
+
+// TestState.php
+
+class TestState extends \Dapr\Actors\ActorState
+{
+    public int $number;
+}
+
+// TestActor.php
+
+#[\Dapr\Actors\Attributes\DaprType('TestActor')]
+class TestActor extends \Dapr\Actors\Actor
+{
+    public function __construct(string $id, private TestState $state)
+    {
+        parent::__construct($id);
+    }
+
+    public function oddIncrement(): bool
+    {
+        if ($this->state->number % 2 === 0) {
+            return false;
+        }
+        $this->state->number += 1;
+
+        return true;
+    }
+}
+
+// TheTest.php
+
+class TheTest extends \PHPUnit\Framework\TestCase
+{
+    private \DI\Container $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        // create a default app and extract the DI container from it
+        $app = \Dapr\App::create(
+            configure: fn(\DI\ContainerBuilder $builder) => $builder->addDefinitions(
+            ['dapr.actors' => [TestActor::class]],
+            [\Dapr\DaprClient::class => \DI\autowire(\Dapr\Mocks\TestClient::class)]
+        ));
+        $app->run(fn(\DI\Container $container) => $this->container = $container);
+    }
+
+    public function testIncrementsWhenOdd()
+    {
+        $id      = uniqid();
+        $runtime = $this->container->get(\Dapr\Actors\ActorRuntime::class);
+        $client  = $this->getClient();
+
+        // return the current state from http://localhost:1313/reference/api/actors_api/
+        $client->register_get("/actors/TestActor/$id/state/number", code: 200, data: 3);
+
+        // ensure it increments from http://localhost:1313/reference/api/actors_api/
+        $client->register_post(
+            "/actors/TestActor/$id/state",
+            code: 204,
+            response_data: null,
+            expected_request: [
+                [
+                    'operation' => 'upsert',
+                    'request'   => [
+                        'key'   => 'number',
+                        'value' => 4,
+                    ],
+                ],
+            ]
+        );
+
+        $result = $runtime->resolve_actor(
+            'TestActor',
+            $id,
+            fn($actor) => $runtime->do_method($actor, 'oddIncrement', null)
+        );
+        $this->assertTrue($result);
+    }
+
+    private function getClient(): \Dapr\Mocks\TestClient
+    {
+        return $this->container->get(\Dapr\DaprClient::class);
+    }
+}
+```
+
+{{% /codetab %}}
+{{% codetab %}}
+
+```php
+<?php
+
+// TestState.php
+
+class TestState extends \Dapr\Actors\ActorState
+{
+    public int $number;
+}
+
+// TestActor.php
+
+#[\Dapr\Actors\Attributes\DaprType('TestActor')]
+class TestActor extends \Dapr\Actors\Actor
+{
+    public function __construct(string $id, private TestState $state)
+    {
+        parent::__construct($id);
+    }
+
+    public function oddIncrement(): bool
+    {
+        if ($this->state->number % 2 === 0) {
+            return false;
+        }
+        $this->state->number += 1;
+
+        return true;
+    }
+}
+
+// TheTest.php
+
+class TheTest extends \PHPUnit\Framework\TestCase
+{
+    public function testNotIncrementsWhenEven() {
+        $container = new \DI\Container();
+        $state = new TestState($container, $container);
+        $state->number = 4;
+        $id = uniqid();
+        $actor = new TestActor($id, $state);
+        $this->assertFalse($actor->oddIncrement());
+        $this->assertSame(4, $state->number);
+    }
+}
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+

--- a/daprdocs/content/en/php-sdk-docs/php-pubsub/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-pubsub/_index.md
@@ -1,0 +1,64 @@
+---
+type: docs
+title: "Publish and Subscribe with PHP"
+linkTitle: "Publish and Subscribe"
+weight: 1000
+description: How to use
+no_list: true
+---
+
+With Dapr, you can publish anything, including cloud events. The SDK contains a simple cloud event implementation, but
+you can also just pass an array that conforms to the cloud event spec or use another library.
+
+```php
+$app->post('/publish', function(\DI\FactoryInterface $factory) {
+    // create a new publisher that publishes to my-pub-sub component
+    $publisher = $factory->make(\Dapr\PubSub\Publish::class, ['pubsub' => 'my-pubsub']);
+    
+    // publish that something happened to my-topic
+    $publisher->topic('my-topic')->publish(['something' => 'happened']);
+});
+```
+
+For more information about publish/subscribe, check out [the howto]({{< ref howto-publish-subscribe.md >}}).
+
+## Data content type
+
+The PHP SDK allows setting the data content type either when constructing a custom cloud event, or when publishing raw
+data.
+
+{{< tabs CloudEvent "Raw" >}}
+
+{{% codetab %}}
+
+```php
+$event = new \Dapr\PubSub\CloudEvent();
+$event->data = $xml;
+$event->data_content_type = 'application/xml';
+```
+
+{{% /codetab %}}
+{{% codetab %}}
+
+```php
+/**
+ * @var \Dapr\PubSub\Publish $publisher 
+ */
+$publisher->topic('my-topic')->publish($raw_data, content_type: 'application/octet-stream');
+```
+
+{{% alert title="Binary data" color="warning" %}}
+
+Only `application/octet-steam` is supported for binary data.
+
+{{% /alert %}}
+
+{{% /codetab %}}
+
+{{< /tabs >}}
+
+## Receiving cloud events
+
+In your subscription handler, you can have the DI Container inject either a `Dapr\PubSub\CloudEvent` or an `array` into
+your controller. The former does some validation to ensure you have a proper event. If you need direct access to the 
+data, or the events do not conform to the spec, use an `array`.

--- a/daprdocs/content/en/php-sdk-docs/php-serialization.md
+++ b/daprdocs/content/en/php-sdk-docs/php-serialization.md
@@ -1,0 +1,54 @@
+---
+type: docs
+title: "Custom Serialization"
+linkTitle: "Custom Serializers"
+weight: 1000
+description: How to configure serialization
+no_list: true
+---
+
+Dapr uses JSON serialization and thus (complex) type information is lost when sending/receiving data.
+
+## Serialization
+
+When returning an object from a controller, passing an object to the `DaprClient`, or storing an object in a state store,
+only public properties are scanned and serialized. You can customize this behavior by implementing `\Dapr\Serialization\ISerialize`.
+For example, if you wanted to create an ID type that serialized to a string, you may implement it like so:
+
+```php
+<?php
+
+class MyId implements \Dapr\Serialization\Serializers\ISerialize 
+{
+    public string $id;
+    
+    public function serialize(mixed $value,\Dapr\Serialization\ISerializer $serializer): mixed
+    {
+        // $value === $this
+        return $this->id; 
+    }
+}
+```
+
+This works for any time that we have full ownership over, however, it doesn't work for classes from libraries or PHP itself.
+For that, you need to register a custom serializer with the DI container:
+
+```php
+// in config.php
+
+class SerializeSomeClass implements \Dapr\Serialization\Serializers\ISerialize 
+{
+    public function serialize(mixed $value,\Dapr\Serialization\ISerializer $serializer) : mixed 
+    {
+        // serialize $value and return the result
+    }
+}
+
+return [
+    'dapr.serializers.custom'      => [SomeClass::class => new SerializeSomeClass()],
+];
+```
+
+## Deserialization
+
+Deserialization works exactly the same way, except the interface is `\Dapr\Deserialization\Deserializers\IDeserialize`.

--- a/daprdocs/content/en/php-sdk-docs/php-serialization.md
+++ b/daprdocs/content/en/php-sdk-docs/php-serialization.md
@@ -30,7 +30,7 @@ class MyId implements \Dapr\Serialization\Serializers\ISerialize
 }
 ```
 
-This works for any time that we have full ownership over, however, it doesn't work for classes from libraries or PHP itself.
+This works for any type that we have full ownership over, however, it doesn't work for classes from libraries or PHP itself.
 For that, you need to register a custom serializer with the DI container:
 
 ```php

--- a/daprdocs/content/en/php-sdk-docs/php-state/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-state/_index.md
@@ -1,0 +1,48 @@
+---
+type: docs 
+title: "State Management with PHP"
+linkTitle: "State management"
+weight: 1000 
+description: How to use 
+no_list: true
+---
+
+Dapr offers a great modular approach to using state in your application. The best way to learn the basics is to visit
+[the howto]({{< ref howto-get-save-state.md >}}).
+
+## Metadata
+
+Many state components allow you to pass metadata to the component to control specific aspects of the component's
+behavior. The PHP SDK allows you to pass that metadata through:
+
+```php
+$app->run(
+    fn(\Dapr\State\StateManager $stateManager) => 
+        $stateManager->save_state('statestore', new \Dapr\State\StateItem('key', 'value', metadata: ['port' => '112'])));
+```
+
+This is an example of how you might pass the port metadata to [Cassandra]({{< ref setup-cassandra.md >}}). 
+
+Every state operation allows passing metadata.
+
+## Consistency/concurrency
+
+In the PHP SDK, there are four classes that represent the four different types of consistency and concurrency in Dapr:
+
+```php
+[
+    \Dapr\consistency\StrongLastWrite::class, 
+    \Dapr\consistency\StrongFirstWrite::class,
+    \Dapr\consistency\EventualLastWrite::class,
+    \Dapr\consistency\EventualFirstWrite::class,
+] 
+```
+
+Passing one of them to a `StateManager` method or using the `StateStore()` attribute allows you to define how the state
+store should handle conflicts.
+
+## Parallelism
+
+When doing a bulk read or beginning a transaction, you can specify the amount of parallelism. Dapr will read "at most"
+that many keys at a time from the underlying store if it has to read one key at a time. This can be helpful to control
+the load on the state store at the expense of performance. The default is `10`.

--- a/daprdocs/content/en/php-sdk-docs/php-state/_index.md
+++ b/daprdocs/content/en/php-sdk-docs/php-state/_index.md
@@ -46,3 +46,46 @@ store should handle conflicts.
 When doing a bulk read or beginning a transaction, you can specify the amount of parallelism. Dapr will read "at most"
 that many keys at a time from the underlying store if it has to read one key at a time. This can be helpful to control
 the load on the state store at the expense of performance. The default is `10`.
+
+## Prefix
+
+Hardcoded key names are useful, but why not make state objects more reusable? When committing a transaction or saving
+an object to state, you can pass a prefix that is applied to every key in the object.
+
+{{< tabs "Transaction prefix" "StateManager prefix" >}}
+
+{{% codetab %}}
+
+```php
+class TransactionObject extends \Dapr\State\TransactionalState {
+    public string $key;
+}
+
+$app->run(function (TransactionObject $object ) {
+    $object->begin(prefix: 'my-prefix-');
+    $object->key = 'value';
+    // commit to key `my-prefix-key`
+    $object->commit();
+});
+```
+
+{{% /codetab %}}
+{{% codetab %}}
+
+```php
+class StateObject {
+    public string $key;
+}
+
+$app->run(function(\Dapr\State\StateManager $stateManager) {
+    $stateManager->load_object($obj = new StateObject(), prefix: 'my-prefix-');
+    // original value is from `my-prefix-key`
+    $obj->key = 'value';
+    // save to `my-prefix-key`
+    $stateManager->save_object($obj, prefix: 'my-prefix-');
+});
+```
+
+{{% /codetab %}}
+
+{{< /tabs >}}


### PR DESCRIPTION
# Description

Adds documentation for [the docs](https://docs.dapr.io/) with https://github.com/dapr/docs/pull/1209.

Goal:

1. To add PHP specific documentation for common use-cases
2. To share advanced scenarios for running in production

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to
implementation.

Please reference the issue this PR will close: #46

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Add actor documentation
* [x] Add state management docs
* [x] Add pubsub docs
* [x] Add serialization docs
* [x] Add unit testing docs