### PR TITLE
The hunt for the empty response

### DIFF
--- a/src/lib/App.php
+++ b/src/lib/App.php
@@ -40,6 +40,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Throwable;
 
 /**
  * Class App
@@ -199,7 +200,7 @@ class App
         } catch (NotFound $exception) {
             $response = $this->psr17Factory->createResponse(404)->withAddedHeader('Content-Type', 'application/json');
             $this->logger->info('Route threw a NotFound exception, returning 404.', ['exception' => $exception]);
-        } catch (Exception $exception) {
+        } catch (Throwable $exception) {
             $response = $this->psr17Factory->createResponse(500)->withBody(
                 $this->psr17Factory->createStream($this->serializer->as_json($exception))
             )->withHeader('Content-Type', 'application/json');


### PR DESCRIPTION
# Description

Occasionally, there were `500` errors with no response and nothing logged. But why? It took a while before I accidentally figured out why. It took a parse error before I re-learned that `Exception` is not the parent exception type, but `Throwable` is. This fixes it.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to
implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
