### PR TITLE
Separate global serializer from internal serializer

### DIFF
--- a/src/lib/Actors/Generators/DynamicGenerator.php
+++ b/src/lib/Actors/Generators/DynamicGenerator.php
@@ -4,8 +4,6 @@ namespace Dapr\Actors\Generators;
 
 use Dapr\Actors\Internal\InternalProxy;
 use Dapr\DaprClient;
-use Dapr\Deserialization\IDeserializer;
-use Dapr\Serialization\ISerializer;
 use DI\FactoryInterface;
 use JetBrains\PhpStorm\Pure;
 use LogicException;
@@ -55,9 +53,9 @@ class DynamicGenerator extends GenerateProxy
     protected function generate_proxy_method(Method $method, string $id): callable
     {
         return function (...$params) use ($method, $id) {
-            $serializer   = $this->container->get(ISerializer::class);
+            $serializer   = $this->container->get('dapr.internal.serializer');
             $client       = $this->container->get(DaprClient::class);
-            $deserializer = $this->container->get(IDeserializer::class);
+            $deserializer = $this->container->get('dapr.internal.deserializer');
             if ( ! empty($params)) {
                 $params = $serializer->as_array($params[0]);
             }


### PR DESCRIPTION
# Description

Separates the internal (de)serializer from an overridable one. Leaving the one that can easily be overridden as the one that processes state.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to
implementation.

Please reference the issue this PR will close: #67 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Tests pass
* [ ] Created/updated tests
* [ ] Extended the documentation
