### PR TITLE
Remove broken link in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -236,10 +236,6 @@ $app->get('/', function(\Dapr\Serialization\ISerializer $serializer) {
 $app->start();
 ```
 
-# Project setup
-
-See [Getting Started](docs/getting-started.md)
-
 # Development
 
 Simply run `composer start` on a machine where `dapr init` has already been run. This will start the daprd service on


### PR DESCRIPTION
Looks like this link was missed when the docs folder was deleted. I assume it is no longer relevant, so I removed the section.