### PR TITLE
Deprecate SecretsManager and test new client

### DIFF
--- a/src/lib/Client/DaprClient.php
+++ b/src/lib/Client/DaprClient.php
@@ -404,12 +404,12 @@ abstract class DaprClient
      * @param array<array-key, string> $metadata
      * @return array<array-key, string>
      */
-    abstract public function getSecret(string $storeName, string $key, array $metadata = []): array;
+    abstract public function getSecret(string $storeName, string $key, array $metadata = []): array|null;
 
     /**
      * @param string $storeName
      * @param array<array-key, string> $metadata
-     * @return PromiseInterface<array<array-key,array<array-key, string>>>
+     * @return PromiseInterface<null|array<array-key,array<array-key, string>>>
      */
     abstract public function getBulkSecretAsync(string $storeName, array $metadata = []): PromiseInterface;
 

--- a/src/lib/SecretManager.php
+++ b/src/lib/SecretManager.php
@@ -3,6 +3,7 @@
 namespace Dapr;
 
 use Dapr\exceptions\DaprException;
+use JetBrains\PhpStorm\Deprecated;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -10,6 +11,7 @@ use Psr\Log\LoggerInterface;
  * @see https://v1-rc1.docs.dapr.io/reference/api/secrets_api/
  * @package Dapr
  */
+#[Deprecated(since: '1.2.0')]
 class SecretManager
 {
     public function __construct(protected DaprClient $client, protected LoggerInterface $logger)

--- a/tests/SecretTest.php
+++ b/tests/SecretTest.php
@@ -5,7 +5,7 @@ use Dapr\SecretManager;
 use DI\DependencyException;
 use DI\NotFoundException;
 
-require_once __DIR__.'/DaprTests.php';
+require_once __DIR__ . '/DaprTests.php';
 
 /**
  * Class SecretTest
@@ -19,6 +19,21 @@ class SecretTest extends DaprTests
      */
     public function testRetrieveSecret()
     {
+        $container = $this->get_http_client_stack(
+            [
+                new \GuzzleHttp\Psr7\Response(200, body: json_encode(['secret' => 'my_secret']))
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $secret = $client->getSecret('store', 'test', ['meta' => 'data']);
+        $this->assertSame(['secret' => 'my_secret'], $secret);
+
+        $request = $container->history[0]['request'];
+        $this->assertRequestQueryString('metadata.meta=data', $request);
+        $this->assertRequestUri('/v1.0/secrets/store/test', $request);
+        $this->assertRequestMethod('GET', $request);
+        $this->assertRequestBody('', $request);
+
         $this->get_client()->register_get(
             '/secrets/store/test',
             200,
@@ -27,7 +42,7 @@ class SecretTest extends DaprTests
             ]
         );
         $secretManager = $this->container->get(SecretManager::class);
-        $secret        = $secretManager->retrieve('store', 'test');
+        $secret = $secretManager->retrieve('store', 'test');
         $this->assertSame(['secret' => 'my_secret'], $secret);
     }
 
@@ -38,13 +53,30 @@ class SecretTest extends DaprTests
      */
     public function testGetAllSecrets()
     {
+        $container = $this->get_http_client_stack(
+            [
+                new \GuzzleHttp\Psr7\Response(
+                    200,
+                    body: json_encode(['secret1' => ['key1' => 'value1'], 'secret2' => ['key2' => 'value2']])
+                )
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $secrets = $client->getBulkSecret('store', ['meta' => 'data']);
+        $this->assertSame(['secret1' => ['key1' => 'value1'], 'secret2' => ['key2' => 'value2']], $secrets);
+        $request = $container->history[0]['request'];
+        $this->assertRequestQueryString('metadata.meta=data', $request);
+        $this->assertRequestUri('/v1.0/secrets/store/bulk', $request);
+        $this->assertRequestMethod('GET', $request);
+        $this->assertRequestBody('', $request);
+
         $this->get_client()->register_get(
             '/secrets/store/bulk',
             200,
             ['secret1' => ['key1' => 'value1'], 'secret2' => ['key2' => 'value2']]
         );
         $secretManager = $this->container->get(SecretManager::class);
-        $secrets       = $secretManager->all('store');
+        $secrets = $secretManager->all('store');
         $this->assertSame(['secret1' => ['key1' => 'value1'], 'secret2' => ['key2' => 'value2']], $secrets);
     }
 
@@ -55,9 +87,25 @@ class SecretTest extends DaprTests
      */
     public function testSecretNoExist()
     {
+        $container = $this->get_http_client_stack(
+            [
+                new \GuzzleHttp\Psr7\Response(
+                    204
+                )
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $secret = $client->getSecret('store', 'test', ['meta' => 'data']);
+        $this->assertNull($secret);
+        $request = $container->history[0]['request'];
+        $this->assertRequestQueryString('metadata.meta=data', $request);
+        $this->assertRequestUri('/v1.0/secrets/store/test', $request);
+        $this->assertRequestMethod('GET', $request);
+        $this->assertRequestBody('', $request);
+
         $this->get_client()->register_get('/secrets/store/test', 204, null);
         $secretManager = $this->container->get(SecretManager::class);
-        $secret        = $secretManager->retrieve('store', 'test');
+        $secret = $secretManager->retrieve('store', 'test');
         $this->assertSame(null, $secret);
     }
 }


### PR DESCRIPTION
# Description

This deprecates the SecretManager and adds tests for the new client

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to
implementation.

Please reference the issue this PR: #36 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Tests pass
* [x] Created/updated tests
* [ ] Extended the documentation
