### PR TITLE
Add isDaprHealthy function to client

### DIFF
--- a/src/lib/Client/DaprClient.php
+++ b/src/lib/Client/DaprClient.php
@@ -420,6 +420,11 @@ abstract class DaprClient
      */
     abstract public function getBulkSecret(string $storeName, array $metadata = []): array;
 
+    /**
+     * Check if the daprd instance is up and running.
+     *
+     * @return bool True if it is running, else false.
+     */
     abstract public function isDaprHealthy(): bool;
 
     /**

--- a/src/lib/Client/DaprClient.php
+++ b/src/lib/Client/DaprClient.php
@@ -420,6 +420,8 @@ abstract class DaprClient
      */
     abstract public function getBulkSecret(string $storeName, array $metadata = []): array;
 
+    abstract public function isDaprHealthy(): bool;
+
     /**
      * @param string $token
      * @return null|array{dapr-api-token: string}

--- a/src/lib/Client/DaprHttpClient.php
+++ b/src/lib/Client/DaprHttpClient.php
@@ -43,4 +43,17 @@ class DaprHttpClient extends DaprClient
             ]
         );
     }
+
+    public function isDaprHealthy(): bool
+    {
+        try {
+            $result = $this->httpClient->get('/v1.0/healthz');
+            if (200 === $result->getStatusCode()) {
+                return true;
+            }
+            return false;
+        } catch (\Throwable $exception) {
+            return false;
+        }
+    }
 }

--- a/tests/HealthTest.php
+++ b/tests/HealthTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+
+/**
+ * Class HealthTest
+ */
+class HealthTest extends DaprTests
+{
+    public function testIsHealthy()
+    {
+        $container = $this->get_http_client_stack(
+            [
+                new Response(200)
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $this->assertTrue($client->isDaprHealthy());
+        $request = $container->history[0]['request'];
+        $this->assertRequestUri('/v1.0/healthz', $request);
+    }
+
+    public function testIsNotHealthy() {
+        $container = $this->get_http_client_stack(
+            [
+                new Response(500)
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $this->assertFalse($client->isDaprHealthy());
+        $request = $container->history[0]['request'];
+        $this->assertRequestUri('/v1.0/healthz', $request);
+    }
+
+    public function testTimeout() {
+        $container = $this->get_http_client_stack(
+            [
+                new RequestException('timed out', new Request('GET', 'test'))
+            ]
+        );
+        $client = $this->get_new_client_with_http($container->client);
+        $this->assertFalse($client->isDaprHealthy());
+        $request = $container->history[0]['request'];
+        $this->assertRequestUri('/v1.0/healthz', $request);
+    }
+}


### PR DESCRIPTION
# Description

This adds the `isDaprHealthy()` function which returns `true` when the sidecar returns a `200`.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to
implementation.

Please reference the issue this PR: #36 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Tests pass
* [x] Created/updated tests
* [ ] Extended the documentation
