### PR TITLE
Standardize user-agent header

### DIFF
--- a/src/lib/Client/DaprHttpClient.php
+++ b/src/lib/Client/DaprHttpClient.php
@@ -38,7 +38,7 @@ class DaprHttpClient extends DaprClient
             'base_uri' => $this->baseHttpUri,
             'allow_redirects' => false,
             'headers' => [
-                'User-Agent' => 'DaprPHPSDK/v1.2',
+                'User-Agent' => 'dapr-sdk-php/v1.2 http/1',
                 'Accept' => 'application/json',
                 'Content-Type' => 'application/json'
             ]


### PR DESCRIPTION
Following on the proposal dapr/dapr#5309, this PR standardizes the value reported in the user-agent header.

The PHP SDK was already reporting itself as being a Dapr SDK, but this changes the format slightly so it's aligned with the proposed standard.